### PR TITLE
fix: pin litellm version

### DIFF
--- a/auto-benchmarkcard/pyproject.toml
+++ b/auto-benchmarkcard/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "langchain-community>=0.3.24",
     "langgraph>=0.6.0",
     "openai>=1.80.0",
-    "litellm>=1.70.0",
+    "litellm==1.79.2",
     "huggingface-hub>=0.32.0",
     "datasets>=3.6.0",
     "transformers>=4.50.0",


### PR DESCRIPTION
Pin litellm version for the AutoBenchmark card demo.  