### PR TITLE
Add a simple risk classifier example using ai atlas nexus outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Note that all contributions to this project are [released][released] to the publ
 | [Gaf-Guard](https://github.com/IBM/ai-atlas-nexus-demos/tree/main/gaf-guard) | risk management, AI agents, | GAF-Guard is an AI framework that can effectively detect and manage risks associated with LLMs for a given use-case.|
 | [Neo4j-Db ](https://github.com/IBM/ai-atlas-nexus-demos/tree/main/neo4j-db) |neo4j, Docker | Set up a docker container with an instance of neo4j community and import the data from AI Atlas Nexus into it. |
 | [AI Atlas Nexus Graph Visualisation ](https://github.com/IBM/ai-atlas-nexus-demos/tree/main/ran-viz) |python, sigmajs, viz, ui | Export AI Atlas Nexus content for a sigmajs graph and display it in the UI. |
+| [AI Atlas Nexus ML Classifier ](https://github.com/IBM/ai-atlas-nexus-demos/tree/main/ran-classifier) | python | Multi-label AI risk classification system that identifies applicable risks from AI use-case descriptions using the ai-atlas-nexus. |
 
 
 ## License

--- a/ran-classifier/AI_Risk_Classifier_Demo.ipynb
+++ b/ran-classifier/AI_Risk_Classifier_Demo.ipynb
@@ -1,0 +1,721 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example AI Risk ML Classifier with IBM Risk Atlas risks\n",
+    "\n",
+    "A multi-label AI risk classification system that identifies applicable risks from AI use-case descriptions using the **IBM Risk Atlas** definitions via ai-atlas-nexus.\n",
+    "\n",
+    "**Approach**: Hybrid scoring combining TF-IDF cosine similarity (vocabulary overlap) and domain keyword extraction (semantic coverage from ontology).\n",
+    "\n",
+    "**Risk Taxonomy**: ~99 risks from the **IBM Risk Atlas**, or another preloaded taxonomy of your choice, or even your own set of risks loaded with the ai-atlas-nexus library.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Install dependencies and import the classifier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install required packages (uncomment if needed)\n",
+    "# !pip install scikit-learn numpy pandas jupyter ai-atlas-nexus\n",
+    "\n",
+    "import sys\n",
+    "sys.path.insert(0, 'classifier')\n",
+    "\n",
+    "from ai_risk_classifier import AIRiskClassifier\n",
+    "import pandas as pd\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialize Classifier with IBM Risk Atlas\n",
+    "\n",
+    "Create an instance of classifer. The risks are loaded dynamically from the toolkit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/ingevejs/Documents/workspace/ingelise/risk-atlas-nexus-demos/.venv/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n",
+      "[2026-08-12 10:43:50:800] - INFO - AIAtlasNexus - Created AIAtlasNexus instance. Base_dir: None\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AIRiskClassifier(n_risks=99, vocab=5335, alpha=0.35, thresholds=(0.12, 0.3))\n",
+      "\n",
+      "Loaded 99 risks from IBM Risk Atlas\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Initialize with IBM Risk Atlas from ai-atlas-nexus\n",
+    "clf = AIRiskClassifier.from_nexus(\n",
+    "    taxonomy='ibm-risk-atlas',     # Use IBM Risk Atlas (default)\n",
+    "    threshold_high=0.30,           # Score ≥ 0.30 → \"high\" relevance\n",
+    "    threshold_medium=0.12,         # Score ≥ 0.12 → \"medium\" relevance\n",
+    "    alpha=0.35,                    # Weight of TF-IDF (0–1); 1-alpha = weight of keywords\n",
+    "    aggregation=\"max\"              # Max or mean across per-anchor TF-IDF scores\n",
+    ")\n",
+    "\n",
+    "print(clf)\n",
+    "print(f\"\\nLoaded {len(clf.taxonomy)} risks from IBM Risk Atlas\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total risks: 99\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Build a taxonomy table from loaded risks\n",
+    "taxonomy_df = pd.DataFrame([\n",
+    "    {\n",
+    "        \"Risk ID\": r[\"id\"],\n",
+    "        \"Label\": r[\"label\"],\n",
+    "        \"Category\": r[\"group\"],\n",
+    "        \"Source\": \", \".join(r[\"sources\"][:1]) if r[\"sources\"] else \"N/A\"\n",
+    "    }\n",
+    "    for r in clf.taxonomy\n",
+    "])\n",
+    "\n",
+    "print(f\"Total risks: {len(taxonomy_df)}\\n\")\n",
+    "\n",
+    "   "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 1: Patient Q&A System\n",
+    "\n",
+    "Analyze risks for an LLM answering patient questions about medications."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Use case: An LLM answers patient questions about medications and symptoms.\n",
+      "Identified 2 risk(s):\n",
+      "  [MEDIUM] Copyright infringement                     score=0.194  █████  kw=[questions ownership, new questions]\n",
+      "  [MEDIUM] Direct instructions attack                 score=0.158  ████  kw=[prompts questions, questions requests]\n"
+     ]
+    }
+   ],
+   "source": [
+    "usecase_1 = \"An LLM answers patient questions about medications and symptoms.\"\n",
+    "\n",
+    "results_1 = clf.identify_risks_from_usecases([usecase_1])\n",
+    "\n",
+    "print(results_1[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Detailed Risk Breakdown for Patient Q&A"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=== HIGH RELEVANCE ===\n",
+      "\n",
+      "=== MEDIUM RELEVANCE ===\n",
+      "  Copyright infringement                             score=0.1937\n",
+      "    Keywords: questions ownership, new questions\n",
+      "  Direct instructions attack                         score=0.1581\n",
+      "    Keywords: prompts questions, questions requests\n"
+     ]
+    }
+   ],
+   "source": [
+    "result = results_1[0]\n",
+    "\n",
+    "# Separate by relevance level\n",
+    "print(\"\\n=== HIGH RELEVANCE ===\")\n",
+    "for risk in result.high:\n",
+    "    print(f\"\\n  {risk.label}\")\n",
+    "    print(f\"    Score: {risk.score:.4f} (TF-IDF: {risk.tfidf_score:.4f}, Keywords: {risk.keyword_score:.4f})\")\n",
+    "    if risk.matched_keywords:\n",
+    "        print(f\"    Matched keywords: {', '.join(risk.matched_keywords[:6])}\")\n",
+    "    print(f\"    Sources: {', '.join(risk.sources)}\")\n",
+    "\n",
+    "print(\"\\n=== MEDIUM RELEVANCE ===\")\n",
+    "for risk in result.medium:\n",
+    "    print(f\"  {risk.label:<50} score={risk.score:.4f}\")\n",
+    "    if risk.matched_keywords:\n",
+    "        print(f\"    Keywords: {', '.join(risk.matched_keywords[:4])}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 2: Multiple Use Cases\n",
+    "\n",
+    "Analyze several diverse AI applications in parallel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Use case: An automated hiring system that screens job applications and ranks candidates.\n",
+      "Identified 1 risk(s):\n",
+      "  [HIGH  ] Impact on Jobs                             score=0.308  █████████  kw=[job loss, job, automated, work automated]\n",
+      "\n",
+      "Use case: A generative AI assistant for creating marketing content and campaigns.\n",
+      "Identified 3 risk(s):\n",
+      "  [MEDIUM] Spreading toxicity                         score=0.211  ██████  kw=[content, content toxic, toxic content, toxicity generative]\n",
+      "  [MEDIUM] Dangerous use                              score=0.137  ████  kw=[evaluated content, content properly]\n",
+      "  [MEDIUM] Spreading disinformation                   score=0.121  ███  kw=[disinformation generative]\n",
+      "\n",
+      "Use case: A machine learning model for approving credit card applications.\n",
+      "Identified 2 risk(s):\n",
+      "  [MEDIUM] Impact on education: bypassing learning    score=0.265  ███████  kw=[learning, learning process, bypass learning, models]\n",
+      "  [MEDIUM] Unexplainable output                       score=0.235  ███████  kw=[models based, learning architectures]\n",
+      "\n",
+      "Use case: A medical AI system that diagnoses diseases from imaging.\n",
+      "Identified 0 risk(s):\n",
+      "\n",
+      "Use case: An LLM chatbot for customer support on an e-commerce platform.\n",
+      "Identified 0 risk(s):\n"
+     ]
+    }
+   ],
+   "source": [
+    "usecases = [\n",
+    "    \"An automated hiring system that screens job applications and ranks candidates.\",\n",
+    "    \"A generative AI assistant for creating marketing content and campaigns.\",\n",
+    "    \"A machine learning model for approving credit card applications.\",\n",
+    "    \"A medical AI system that diagnoses diseases from imaging.\",\n",
+    "    \"An LLM chatbot for customer support on an e-commerce platform.\",\n",
+    "]\n",
+    "\n",
+    "results = clf.identify_risks_from_usecases(usecases)\n",
+    "\n",
+    "for i, result in enumerate(results, 1):\n",
+    "    print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 3: Risk Score Matrix\n",
+    "\n",
+    "Get raw scores for all use cases and risks (useful for downstream analysis and sklearn pipelines)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Score matrix shape: (5, 99)\n",
+      "  Rows: 5 use cases\n",
+      "  Cols: 99 risks\n",
+      "\n",
+      "                                                  evasion-attack  \\\n",
+      "UC1: An automated hiring system that screens ...          0.0000   \n",
+      "UC2: A generative AI assistant for creating m...          0.0000   \n",
+      "UC3: A machine learning model for approving c...          0.0093   \n",
+      "UC4: A medical AI system that diagnoses disea...          0.0000   \n",
+      "UC5: An LLM chatbot for customer support on a...          0.0000   \n",
+      "\n",
+      "                                                  impact-on-the-environment  \\\n",
+      "UC1: An automated hiring system that screens ...                     0.0059   \n",
+      "UC2: A generative AI assistant for creating m...                     0.1030   \n",
+      "UC3: A machine learning model for approving c...                     0.0745   \n",
+      "UC4: A medical AI system that diagnoses disea...                     0.0086   \n",
+      "UC5: An LLM chatbot for customer support on a...                     0.0322   \n",
+      "\n",
+      "                                                  incorrect-risk-testing  \\\n",
+      "UC1: An automated hiring system that screens ...                  0.0055   \n",
+      "UC2: A generative AI assistant for creating m...                  0.0057   \n",
+      "UC3: A machine learning model for approving c...                  0.0068   \n",
+      "UC4: A medical AI system that diagnoses disea...                  0.0039   \n",
+      "UC5: An LLM chatbot for customer support on a...                  0.0062   \n",
+      "\n",
+      "                                                  over-or-under-reliance  \\\n",
+      "UC1: An automated hiring system that screens ...                  0.0133   \n",
+      "UC2: A generative AI assistant for creating m...                  0.0067   \n",
+      "UC3: A machine learning model for approving c...                  0.0085   \n",
+      "UC4: A medical AI system that diagnoses disea...                  0.0370   \n",
+      "UC5: An LLM chatbot for customer support on a...                  0.0082   \n",
+      "\n",
+      "                                                  membership-inference-attack  \\\n",
+      "UC1: An automated hiring system that screens ...                       0.0117   \n",
+      "UC2: A generative AI assistant for creating m...                       0.0064   \n",
+      "UC3: A machine learning model for approving c...                       0.0771   \n",
+      "UC4: A medical AI system that diagnoses disea...                       0.0034   \n",
+      "UC5: An LLM chatbot for customer support on a...                       0.0161   \n",
+      "\n",
+      "                                                  confidential-data-in-prompt  \\\n",
+      "UC1: An automated hiring system that screens ...                       0.0069   \n",
+      "UC2: A generative AI assistant for creating m...                       0.0031   \n",
+      "UC3: A machine learning model for approving c...                       0.0080   \n",
+      "UC4: A medical AI system that diagnoses disea...                       0.0077   \n",
+      "UC5: An LLM chatbot for customer support on a...                       0.0000   \n",
+      "\n",
+      "                                                  prompt-leaking  \\\n",
+      "UC1: An automated hiring system that screens ...          0.0255   \n",
+      "UC2: A generative AI assistant for creating m...          0.0764   \n",
+      "UC3: A machine learning model for approving c...          0.0065   \n",
+      "UC4: A medical AI system that diagnoses disea...          0.0286   \n",
+      "UC5: An LLM chatbot for customer support on a...          0.0079   \n",
+      "\n",
+      "                                                  data-privacy-rights  \\\n",
+      "UC1: An automated hiring system that screens ...               0.0015   \n",
+      "UC2: A generative AI assistant for creating m...               0.0071   \n",
+      "UC3: A machine learning model for approving c...               0.0143   \n",
+      "UC4: A medical AI system that diagnoses disea...               0.0122   \n",
+      "UC5: An LLM chatbot for customer support on a...               0.0078   \n",
+      "\n",
+      "                                                  discriminatory-actions-agentic  \\\n",
+      "UC1: An automated hiring system that screens ...                          0.0133   \n",
+      "UC2: A generative AI assistant for creating m...                          0.0135   \n",
+      "UC3: A machine learning model for approving c...                          0.0084   \n",
+      "UC4: A medical AI system that diagnoses disea...                          0.0118   \n",
+      "UC5: An LLM chatbot for customer support on a...                          0.0201   \n",
+      "\n",
+      "                                                  ip-information-in-prompt  \\\n",
+      "UC1: An automated hiring system that screens ...                    0.0057   \n",
+      "UC2: A generative AI assistant for creating m...                    0.0096   \n",
+      "UC3: A machine learning model for approving c...                    0.0130   \n",
+      "UC4: A medical AI system that diagnoses disea...                    0.0064   \n",
+      "UC5: An LLM chatbot for customer support on a...                    0.0056   \n",
+      "\n",
+      "                                                  ...  unexplainable-output  \\\n",
+      "UC1: An automated hiring system that screens ...  ...                0.0030   \n",
+      "UC2: A generative AI assistant for creating m...  ...                0.0127   \n",
+      "UC3: A machine learning model for approving c...  ...                0.2355   \n",
+      "UC4: A medical AI system that diagnoses disea...  ...                0.0000   \n",
+      "UC5: An LLM chatbot for customer support on a...  ...                0.0168   \n",
+      "\n",
+      "                                                  human-exploitation  \\\n",
+      "UC1: An automated hiring system that screens ...              0.0076   \n",
+      "UC2: A generative AI assistant for creating m...              0.0102   \n",
+      "UC3: A machine learning model for approving c...              0.0108   \n",
+      "UC4: A medical AI system that diagnoses disea...              0.0076   \n",
+      "UC5: An LLM chatbot for customer support on a...              0.0149   \n",
+      "\n",
+      "                                                  toxic-output  \\\n",
+      "UC1: An automated hiring system that screens ...        0.0053   \n",
+      "UC2: A generative AI assistant for creating m...        0.0859   \n",
+      "UC3: A machine learning model for approving c...        0.0061   \n",
+      "UC4: A medical AI system that diagnoses disea...        0.0000   \n",
+      "UC5: An LLM chatbot for customer support on a...        0.0000   \n",
+      "\n",
+      "                                                  unexplainable-untraceable-actions-agentic  \\\n",
+      "UC1: An automated hiring system that screens ...                                     0.0064   \n",
+      "UC2: A generative AI assistant for creating m...                                     0.0204   \n",
+      "UC3: A machine learning model for approving c...                                     0.0189   \n",
+      "UC4: A medical AI system that diagnoses disea...                                     0.0053   \n",
+      "UC5: An LLM chatbot for customer support on a...                                     0.0103   \n",
+      "\n",
+      "                                                  data-poisoning  \\\n",
+      "UC1: An automated hiring system that screens ...          0.0091   \n",
+      "UC2: A generative AI assistant for creating m...          0.0063   \n",
+      "UC3: A machine learning model for approving c...          0.0106   \n",
+      "UC4: A medical AI system that diagnoses disea...          0.0000   \n",
+      "UC5: An LLM chatbot for customer support on a...          0.0215   \n",
+      "\n",
+      "                                                  unreliable-source-attribution  \\\n",
+      "UC1: An automated hiring system that screens ...                         0.0109   \n",
+      "UC2: A generative AI assistant for creating m...                         0.0083   \n",
+      "UC3: A machine learning model for approving c...                         0.0127   \n",
+      "UC4: A medical AI system that diagnoses disea...                         0.0448   \n",
+      "UC5: An LLM chatbot for customer support on a...                         0.0091   \n",
+      "\n",
+      "                                                  temporal-gap  \\\n",
+      "UC1: An automated hiring system that screens ...        0.0058   \n",
+      "UC2: A generative AI assistant for creating m...        0.0043   \n",
+      "UC3: A machine learning model for approving c...        0.0028   \n",
+      "UC4: A medical AI system that diagnoses disea...        0.0118   \n",
+      "UC5: An LLM chatbot for customer support on a...        0.0000   \n",
+      "\n",
+      "                                                  lack-domain-expertise  \\\n",
+      "UC1: An automated hiring system that screens ...                 0.0064   \n",
+      "UC2: A generative AI assistant for creating m...                 0.0078   \n",
+      "UC3: A machine learning model for approving c...                 0.0713   \n",
+      "UC4: A medical AI system that diagnoses disea...                 0.0068   \n",
+      "UC5: An LLM chatbot for customer support on a...                 0.0000   \n",
+      "\n",
+      "                                                  exclusion  overfitting  \n",
+      "UC1: An automated hiring system that screens ...     0.0709       0.0070  \n",
+      "UC2: A generative AI assistant for creating m...     0.0083       0.0137  \n",
+      "UC3: A machine learning model for approving c...     0.0032       0.0731  \n",
+      "UC4: A medical AI system that diagnoses disea...     0.0717       0.0110  \n",
+      "UC5: An LLM chatbot for customer support on a...     0.0000       0.0891  \n",
+      "\n",
+      "[5 rows x 99 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get raw score matrix: (n_usecases, n_risks)\n",
+    "score_matrix = clf.score(usecases)\n",
+    "\n",
+    "print(f\"Score matrix shape: {score_matrix.shape}\")\n",
+    "print(f\"  Rows: {score_matrix.shape[0]} use cases\")\n",
+    "print(f\"  Cols: {score_matrix.shape[1]} risks\\n\")\n",
+    "\n",
+    "# Create a detailed DataFrame\n",
+    "risk_ids = clf.risk_ids()\n",
+    "score_df = pd.DataFrame(\n",
+    "    score_matrix,\n",
+    "    columns=risk_ids,\n",
+    "    index=[f\"UC{i+1}: {uc[:40]}...\" for i, uc in enumerate(usecases)]\n",
+    ")\n",
+    "\n",
+    "# Display rounded scores\n",
+    "display_df = score_df.copy()\n",
+    "display_df = display_df.round(4)\n",
+    "print(display_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Risk Distribution Analysis\n",
+    "\n",
+    "Which risks are most common across the use cases?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Top risks by average score across all use cases:\n",
+      "                  Risk ID  Avg Score  Max Score  Min Score\n",
+      "           impact-on-jobs   0.084713   0.308467   0.005049\n",
+      "       bypassing-learning   0.066350   0.265245   0.005158\n",
+      "  reproducibility-agentic   0.054089   0.110232   0.000000\n",
+      "     unexplainable-output   0.053602   0.235514   0.000000\n",
+      "            dangerous-use   0.049251   0.136706   0.006695\n",
+      "       spreading-toxicity   0.045439   0.211007   0.000000\n",
+      "impact-on-the-environment   0.044833   0.102995   0.005926\n",
+      "  harmful-code-generation   0.041650   0.072007   0.000000\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Average score per risk across all use cases\n",
+    "avg_scores = score_matrix.mean(axis=0)\n",
+    "risk_importance = pd.DataFrame({\n",
+    "    'Risk ID': risk_ids,\n",
+    "    'Avg Score': avg_scores,\n",
+    "    'Max Score': score_matrix.max(axis=0),\n",
+    "    'Min Score': score_matrix.min(axis=0),\n",
+    "})\n",
+    "\n",
+    "risk_importance = risk_importance.sort_values('Avg Score', ascending=False)\n",
+    "print(\"\\nTop risks by average score across all use cases:\")\n",
+    "print(risk_importance.head(8).to_string(index=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 4: Custom Thresholds\n",
+    "\n",
+    "Create a more sensitive classifier (lower thresholds = more risks detected)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2026-08-12 10:43:51:768] - INFO - AIAtlasNexus - Created AIAtlasNexus instance. Base_dir: None\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "=== STRICT CLASSIFIER ===\n",
+      "\n",
+      "Use case: A chatbot for general customer service.\n",
+      "Identified 2 risk(s):\n",
+      "  [MEDIUM] Model usage rights restrictions            score=0.120  ███  kw=[service licenses]\n",
+      "  [MEDIUM] Data usage rights restrictions             score=0.118  ███  kw=[service license]\n",
+      "\n",
+      "Total risks detected (strict): 2\n",
+      "  High: 0, Medium: 2\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Strict classifier: lower thresholds catch more marginal risks\n",
+    "strict_clf = AIRiskClassifier.from_nexus(\n",
+    "    taxonomy='ibm-risk-atlas',   \n",
+    "    threshold_high=0.20,\n",
+    "    threshold_medium=0.08,\n",
+    "    alpha=0.4,\n",
+    ")\n",
+    "\n",
+    "strict_results = strict_clf.identify_risks_from_usecases(\n",
+    "    [\"A chatbot for general customer service.\"]\n",
+    ")\n",
+    "\n",
+    "print(\"\\n=== STRICT CLASSIFIER ===\")\n",
+    "print(strict_results[0])\n",
+    "\n",
+    "print(f\"\\nTotal risks detected (strict): {len(strict_results[0].risks)}\")\n",
+    "print(f\"  High: {len(strict_results[0].high)}, Medium: {len(strict_results[0].medium)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 5: Keyword Matching Deep Dive\n",
+    "\n",
+    "Understand how keyword matching contributes to risk scores."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Use case: A system that automatically decides parole recommendations for incarcerated individuals.\n",
+      "Identified 4 risk(s):\n",
+      "  [MEDIUM] Incomplete advice                          score=0.163  ████  kw=[recommendations, advice recommendations]\n",
+      "  [MEDIUM] Output bias                                score=0.163  ████  kw=[individuals bias, groups individuals]\n",
+      "  [MEDIUM] Attribute inference attack                 score=0.147  ████  kw=[inferred individuals]\n",
+      "  [MEDIUM] Data privacy rights alignment              score=0.145  ████  kw=[individuals seemingly, reidentification individuals]\n",
+      "\n",
+      "=== KEYWORD ANALYSIS ===\n"
+     ]
+    }
+   ],
+   "source": [
+    "usecase = \"A system that automatically decides parole recommendations for incarcerated individuals.\"\n",
+    "results_parole = clf.identify_risks_from_usecases([usecase])\n",
+    "\n",
+    "print(results_parole[0])\n",
+    "\n",
+    "print(\"\\n=== KEYWORD ANALYSIS ===\")\n",
+    "for risk in results_parole[0].high:\n",
+    "    print(f\"\\n{risk.label}\")\n",
+    "    print(f\"  Score: {risk.score:.4f}\")\n",
+    "    print(f\"  TF-IDF: {risk.tfidf_score:.4f} | Keywords: {risk.keyword_score:.4f}\")\n",
+    "    print(f\"  Matched keywords: {risk.matched_keywords}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 6: Exporting Results\n",
+    "\n",
+    "Convert results to JSON/dict for integration with other systems."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"usecase\": \"A system that automatically decides parole recommendations for incarcerated individuals.\",\n",
+      "  \"risks\": [\n",
+      "    {\n",
+      "      \"id\": \"incomplete-advice\",\n",
+      "      \"label\": \"Incomplete advice\",\n",
+      "      \"group\": \"output\",\n",
+      "      \"relevance\": \"medium\",\n",
+      "      \"score\": 0.1628,\n",
+      "      \"matched_keywords\": [\n",
+      "        \"recommendations\",\n",
+      "        \"advice recommendations\"\n",
+      "      ],\n",
+      "      \"sources\": [\n",
+      "        \"ibm-risk-atlas\"\n",
+      "      ]\n",
+      "    },\n",
+      "    {\n",
+      "      \"id\": \"output-bias\",\n",
+      "      \"label\": \"Output bias\",\n",
+      "      \"gr...\n",
+      "\n",
+      "Exported 6 risk findings across 5 use cases\n",
+      "                                             usecase         risk_id  \\\n",
+      "0  An automated hiring system that screens job ap...  impact-on-jobs   \n",
+      "\n",
+      "       risk_label       category relevance   score  tfidf_score  keyword_score  \n",
+      "0  Impact on Jobs  non-technical      high  0.3085       0.1385            0.4  \n"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "\n",
+    "# Convert to structured format\n",
+    "result_dict = results_parole[0].to_dict()\n",
+    "\n",
+    "print(json.dumps(result_dict, indent=2)[:500] + \"...\")\n",
+    "\n",
+    "# Export all results as DataFrame\n",
+    "all_findings = []\n",
+    "for result in results:\n",
+    "    for risk in result.risks:\n",
+    "        all_findings.append({\n",
+    "            'usecase': result.usecase[:50],\n",
+    "            'risk_id': risk.id,\n",
+    "            'risk_label': risk.label,\n",
+    "            'category': risk.group,\n",
+    "            'relevance': risk.relevance,\n",
+    "            'score': risk.score,\n",
+    "            'tfidf_score': risk.tfidf_score,\n",
+    "            'keyword_score': risk.keyword_score,\n",
+    "        })\n",
+    "\n",
+    "findings_df = pd.DataFrame(all_findings)\n",
+    "print(f\"\\nExported {len(findings_df)} risk findings across {len(usecases)} use cases\")\n",
+    "print(findings_df[findings_df['relevance'] == 'high'].head(10))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "The AI Risk Classifier provides a way to build an AI risk identification ml classifier using the **IBM Risk Atlas** outputs:\n",
+    "\n",
+    "### Key Features\n",
+    "- **Live ontology**: Works with ~99 risks from the IBM Risk Atlas via ai-atlas-nexus\n",
+    "- **No training required**: Works out-of-the-box with risk descriptions and extracted keywords\n",
+    "- **Interpretable**: Hybrid scoring combines TF-IDF similarity + domain keyword extraction\n",
+    "- **Configurable**: Adjust thresholds and weighting to match your risk tolerance\n",
+    "- **Extensible**: Works with any risk taxonomy from ai-atlas-nexus (NIST, MIT, OWASP, etc.)\n",
+    "- **sklearn-compatible**: `.score()` method returns matrices suitable for ML pipelines\n",
+    "\n",
+    "### Possible Use Cases\n",
+    "1. **AI audit workflows**: Quickly identify risks in proposed AI applications\n",
+    "2. **Risk inventory**: Screen multiple use cases for comparative risk assessment\n",
+    "3. **Compliance checks**: Automatic flagging of high-risk domains (healthcare, finance, hiring)\n",
+    "4. **Threshold calibration**: Benchmark against labelled data to optimize for your deployment\n",
+    "5. **Downstream ML**: Integrate scores as features in broader governance systems\n",
+    "\n",
+    "### Supported Taxonomies\n",
+    "You can initialize the classifier with different taxonomies from ai-atlas-nexus:\n",
+    "```python\n",
+    "AIRiskClassifier.from_nexus(taxonomy='nist-ai-rmf')      # NIST\n",
+    "AIRiskClassifier.from_nexus(taxonomy='mit-ai-risk-repository')  # MIT\n",
+    "AIRiskClassifier.from_nexus(taxonomy='owasp-llm-2.0')    # OWASP\n",
+    "AIRiskClassifier.from_nexus(taxonomy='ibm-risk-atlas')   # IBM (default)\n",
+    "```\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/ran-classifier/README.md
+++ b/ran-classifier/README.md
@@ -1,0 +1,254 @@
+# AI Risk Classifier — Atlas Nexus Demo
+
+A lightweight, interpretable multi-label AI risk classifier that identifies applicable risks from AI use-case descriptions.
+
+## Quick Start
+
+### Installation
+
+```bash
+pip install scikit-learn numpy pandas
+```
+
+### Basic Usage
+
+```python
+from classifier.ai_risk_classifier import AIRiskClassifier
+
+# Initialize classifier
+clf = AIRiskClassifier()
+
+# Identify risks for use cases
+results = clf.identify_risks_from_usecases([
+    "An LLM answers patient questions about medications."
+])
+
+# Print results
+for result in results:
+    print(result)
+```
+
+### Output Example
+
+```
+Use case: An LLM answers patient questions about medications.
+Identified 5 risk(s):
+  [HIGH  ] Hallucination / Confabulation             score=0.578  ███████████████████████████████████ kw=[medical, health, patient, medication]
+  [HIGH  ] Harmful Output                             score=0.401  ██████████████████████ kw=[medical, patient, medication, safety]
+  [MEDIUM] Privacy Violation / Data Leakage           score=0.168  █████████ kw=[patient, health, medical, personal]
+  [MEDIUM] Regulatory Non-Compliance                  score=0.157  █████████ kw=[medical, healthcare, patient, health]
+  [MEDIUM] Lack of Explainability / Transparency     score=0.143  ████████
+```
+
+## Interactive Demo
+
+Run the comprehensive Jupyter notebook for hands-on examples:
+
+```bash
+jupyter notebook AI_Risk_Classifier_Demo.ipynb
+```
+
+The notebook includes:
+- Taxonomy overview
+- Single use-case analysis
+- Batch processing multiple use cases
+- Score matrix generation for downstream ML
+- Custom threshold tuning
+- Keyword matching deep dive
+- Results export
+
+## Architecture
+
+### Hybrid Scoring
+
+The classifier combines two complementary signals:
+
+1. **TF-IDF Cosine Similarity** — Surface-level vocabulary overlap
+   - Use-case is vectorized and compared against per-risk anchor sentences
+   - Score = max cosine similarity across a risk's anchors (configurable)
+
+2. **Domain Keyword Matching** — Semantic coverage for domain terminology
+   - Use-case is tokenized into unigrams, bigrams, and light-stemmed forms
+   - Intersection with curated per-risk keyword vocabulary
+   - Score = hits / normalizer (capped at 1.0)
+
+**Final Score**: `alpha * tfidf_score + (1 - alpha) * keyword_score`
+
+### Risk Taxonomy
+
+16 curated risks across 7 categories:
+
+| Category | Risks |
+|----------|-------|
+| **Reliability** | Hallucination, Overreliance |
+| **Safety** | Harmful Output, Toxic Content, Misinformation, Social Engineering |
+| **Fairness** | Output Bias / Discrimination |
+| **Security** | Jailbreaking / Prompt Injection, Data/Model Poisoning |
+| **Privacy** | Privacy Violation / Data Leakage |
+| **Transparency** | Lack of Explainability |
+| **Legal** | Copyright / IP Violation, Regulatory Non-Compliance |
+| **Governance** | Third-Party / Supply Chain Risk, Lack of Accountability, Environmental Impact |
+
+**Sources**: IBM AI Risk Atlas, NIST AI RMF, MIT Risk Repository, OWASP Top 10 for LLMs
+
+## API Reference
+
+### `AIRiskClassifier`
+
+```python
+clf = AIRiskClassifier(
+    threshold_high=0.30,       # Score ≥ this → "high" relevance
+    threshold_medium=0.12,     # Score ≥ this → "medium" relevance
+    alpha=0.35,                # Weight of TF-IDF (0–1)
+    taxonomy=None,             # Custom risk taxonomy (None = built-in 16 risks)
+    aggregation="max"          # "max" or "mean" for per-anchor TF-IDF aggregation
+)
+```
+
+#### Methods
+
+**`identify_risks_from_usecases(usecases: List[str]) → List[UsecaseRiskResult]`**
+
+Identify applicable risks for one or more use-case descriptions.
+
+Returns a list of `UsecaseRiskResult` objects with properties:
+- `.risks` — all identified risks (sorted by score, descending)
+- `.high` — high-relevance risks only
+- `.medium` — medium-relevance risks only
+- `.low` — low-relevance risks only (empty if threshold_medium is set)
+- `.to_dict()` — convert to JSON-serializable dict
+
+**`score(usecases: List[str]) → np.ndarray`**
+
+Return raw score matrix (n_usecases × n_risks). Suitable for sklearn pipelines and downstream analysis.
+
+**`risk_ids() → List[str]`**
+
+Return list of risk IDs in taxonomy order.
+
+### Data Classes
+
+**`IdentifiedRisk`**
+- `id` — Risk identifier
+- `label` — Human-readable risk label
+- `group` — Risk category
+- `sources` — Authoritative sources (IBM, NIST, OWASP, MIT)
+- `score` — Final hybrid score (0–1)
+- `tfidf_score` — TF-IDF component (0–1)
+- `keyword_score` — Keyword component (0–1)
+- `relevance` — "high" or "medium"
+- `matched_keywords` — Keywords that contributed to the score
+
+**`UsecaseRiskResult`**
+- `usecase` — Original use-case string
+- `risks` — List of `IdentifiedRisk` objects
+
+## Configuration
+
+### Threshold Tuning
+
+Adjust thresholds to match your risk tolerance:
+
+```python
+# Conservative: fewer false positives
+conservative = AIRiskClassifier(threshold_high=0.40, threshold_medium=0.20)
+
+# Aggressive: catch marginal risks
+aggressive = AIRiskClassifier(threshold_high=0.20, threshold_medium=0.08)
+```
+
+### TF-IDF / Keyword Weighting
+
+Control the balance between vocabulary similarity and domain terminology:
+
+```python
+# More keyword-driven (good for domains with standard terminology)
+keyword_heavy = AIRiskClassifier(alpha=0.25)
+
+# More TF-IDF (good for novel use-case descriptions)
+tfidf_heavy = AIRiskClassifier(alpha=0.50)
+```
+
+### Custom Taxonomy
+
+Use domain-specific risks instead of the built-in set:
+
+```python
+custom_taxonomy = [
+    {
+        "id": "my-risk",
+        "label": "My Custom Risk",
+        "group": "custom",
+        "sources": ["Internal Policy"],
+        "anchors": ["description of when this risk applies"],
+        "keywords": ["key", "domain", "terms"],
+        "kw_norm": 3,
+    },
+    # ... more risks
+]
+
+clf = AIRiskClassifier(taxonomy=custom_taxonomy)
+```
+
+## Use Cases
+
+### 1. AI Audit Workflow
+Screen proposed AI applications for risk surface before development:
+```python
+proposed_usecases = ["...", "...", "..."]
+results = clf.identify_risks_from_usecases(proposed_usecases)
+high_risk = [r for r in results if r.high]
+```
+
+### 2. Compliance Checks
+Automatically flag applications in regulated domains:
+```python
+# Identify healthcare use cases with regulatory risk
+for result in results:
+    if any(r.id == "regulatory-non-compliance" and r.relevance == "high" 
+           for r in result.risks):
+        print(f"⚠️  Regulatory review needed: {result.usecase}")
+```
+
+### 3. ML Pipeline Integration
+Use scores as features in broader governance systems:
+```python
+score_matrix = clf.score(usecases)  # (n_usecases, 16)
+# Feed into downstream risk models, dashboards, alerting, etc.
+```
+
+### 4. Threshold Calibration
+If you have labelled data, optimize thresholds for your deployment:
+```python
+from sklearn.model_selection import cross_val_score
+
+# Test threshold combinations
+for threshold in np.arange(0.1, 0.5, 0.05):
+    clf_tuned = AIRiskClassifier(threshold_high=threshold)
+    scores = cross_val_score(clf_tuned, X, y, cv=5)
+    print(f"Threshold {threshold}: {scores.mean():.3f}")
+```
+
+## Limitations
+
+- **No training data required**, but thresholds are calibrated to general AI risk landscapes
+- **Anchor sentences and keywords are static** — cannot adapt to novel risk formulations
+- **Vocabulary overlap bias** — may miss risks that use different terminology
+- **No temporal reasoning** — cannot reason about sequential or causal relationships in use cases
+- **Assumes English text** — TF-IDF vectorizer optimized for English
+
+## References
+
+- [IBM AI Risk Atlas](https://www.ibm.com/ai-risk-atlas)
+- [NIST AI Risk Management Framework](https://nvlpubs.nist.gov/nistpubs/ai/NIST.AI.600-1.pdf)
+- [OWASP Top 10 for Large Language Models](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
+- [MIT AI Risk Repository](https://air.mit.edu/)
+- [IBM Granite Guardian](https://research.ibm.com/blog/granite-guardian)
+
+## License
+
+Same as parent repository (see `LICENSE` in root).
+
+---
+
+**Part of**: [AI Atlas Nexus Demos](https://github.com/IBM/risk-atlas-nexus-demos)

--- a/ran-classifier/classifier/ai_risk_classifier.py
+++ b/ran-classifier/classifier/ai_risk_classifier.py
@@ -1,0 +1,593 @@
+"""
+ai_risk_classifier.py
+─────────────────────
+Multi-label AI risk classifier using ai-atlas-nexus ontology or static taxonomy.
+
+Architecture
+────────────
+Hybrid scorer combining two complementary signals:
+
+  1. TF-IDF cosine similarity  (surface-level vocabulary overlap)
+     The use-case is vectorised and compared against risk descriptions/anchors.
+     Score = max cosine similarity across a risk's text anchors.
+
+  2. Domain keyword matching  (semantic coverage for domain terminology)
+     Keywords extracted from risk name/description/concern.
+     The use-case is tokenised into words + bigrams, light-stemmed, and intersected
+     with risk keywords.  Score = hits / normaliser (capped 1).
+
+  Final score = alpha * tfidf + (1-alpha) * keyword_score
+
+The classifier can be initialized with:
+  - Risk objects from ai-atlas-nexus (live ontology, Option B)
+  - Static taxonomy dict (legacy, Option A)
+  - Custom taxonomy
+
+Dependencies
+────────────
+    pip install scikit-learn numpy
+    pip install ai-atlas-nexus  (optional, for nexus integration)
+
+Usage
+─────
+    from ai_risk_classifier import AIRiskClassifier
+
+    # Use IBM Risk Atlas from ai-atlas-nexus
+    clf = AIRiskClassifier.from_nexus(taxonomy='ibm-risk-atlas')
+
+    results = clf.identify_risks_from_usecases(
+        usecases=["An LLM answers patient questions about medications."]
+    )
+    for r in results:
+        print(r)
+"""
+
+from __future__ import annotations
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional, Any
+import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+_STEM_SUFFIXES = ("ing", "tion", "ations", "ments", "ment", "ers", "ises",
+                  "izes", "ises", "izes", "ised", "ized", "ed", "es", "s")
+
+def _stem(word: str) -> str:
+    """Very light suffix stripping — avoids dependency on NLTK."""
+    for sfx in _STEM_SUFFIXES:
+        if word.endswith(sfx) and len(word) - len(sfx) >= 3:
+            return word[: -len(sfx)]
+    return word
+
+
+def _build_extraction_text(risk: Any) -> str:
+    """
+    Assemble text from a Risk object for corpus-level keyword extraction.
+    Concatenates name, description, concern, descriptor fields.
+    """
+    parts = []
+
+    if hasattr(risk, "name") and risk.name:
+        parts.append(risk.name)
+
+    if hasattr(risk, "description") and risk.description:
+        parts.append(risk.description)
+
+    if hasattr(risk, "concern") and risk.concern:
+        parts.append(risk.concern)
+
+    if hasattr(risk, "descriptor") and risk.descriptor:
+        if isinstance(risk.descriptor, list):
+            parts.extend(risk.descriptor)
+        else:
+            parts.append(str(risk.descriptor))
+
+    return " ".join(str(p) for p in parts if p)
+
+
+# Domain-generic words to filter only in compound phrases (bigrams).
+# Single-word keywords survive here; they're already filtered by max_df in the TfidfVectorizer.
+# These are extremely common generics that never distinguish one risk from another.
+_DOMAIN_GENERIC_COMPOUND_WORDS = {
+    'data', 'model', 'system',  # too generic even in bigrams
+}
+
+
+def _extract_keywords_corpus(
+    texts: list[str],
+    top_k: int = 20,
+    max_df: float = 0.5,
+    min_word_len: int = 3,
+) -> list[list[str]]:
+    """
+    Extract keywords from a corpus of risk texts using TF-IDF scoring.
+
+    Applies corpus-level filtering to eliminate generic terms:
+    - Removes English stopwords (a, the, in, on, etc.)
+    - Drops terms appearing in >max_df fraction of documents (e.g. "user", "system")
+    - Filters domain-generic words ("model", "data", "system", etc.)
+    - Ranks remaining terms by TF-IDF weight (frequent in one risk, rare elsewhere)
+
+    Parameters
+    ----------
+    texts : list[str]
+        Risk descriptions, one per element (aligned with returned keyword lists).
+    top_k : int
+        How many top TF-IDF keywords to keep per risk (default 20).
+    max_df : float
+        Ignore terms appearing in more than max_df fraction of documents (default 0.5).
+        E.g. 0.5 drops any term in >50% of risks.
+    min_word_len : int
+        Ignore tokens shorter than this (default 3, filters "a", "ai", "or").
+
+    Returns
+    -------
+    list[list[str]]
+        Keywords per risk, aligned by index with `texts`.
+        Each sublist is sorted by TF-IDF weight descending.
+    """
+    if not texts:
+        return []
+
+    # Fit TF-IDF vectorizer across all risk texts
+    vectorizer = TfidfVectorizer(
+        stop_words="english",
+        max_df=max_df,
+        min_df=1,
+        ngram_range=(1, 2),
+        token_pattern=rf"(?u)\b[a-zA-Z]{{{min_word_len},}}\b",
+        lowercase=True,
+        strip_accents="unicode",
+    )
+    tfidf_matrix = vectorizer.fit_transform(texts)
+    feature_names = vectorizer.get_feature_names_out()
+
+    # Extract top-k keywords per document based on TF-IDF weight
+    result = []
+    for row_idx in range(tfidf_matrix.shape[0]):
+        # Get nonzero TF-IDF scores for this document
+        scores = tfidf_matrix[row_idx].toarray().flatten()
+        # Get indices sorted by score descending
+        sorted_indices = np.argsort(-scores)
+        # Take top-k nonzero features, filtering only the most generic compound phrases
+        top_features = []
+        for idx in sorted_indices:
+            if scores[idx] > 0 and len(top_features) < top_k:
+                feature = feature_names[idx]
+                # Filter compound phrases containing extremely generic terms.
+                # Single-word keywords already handled by max_df and stopwords.
+                if ' ' in feature:
+                    words_in_feature = feature.split()
+                    if any(w in _DOMAIN_GENERIC_COMPOUND_WORDS for w in words_in_feature):
+                        continue
+                top_features.append(feature)
+        result.append(top_features)
+
+    return result
+
+
+def _tokenize(text: str) -> set[str]:
+    """
+    Return a set of unigrams + bigrams (original + light-stemmed).
+    """
+    words = re.findall(r"[a-z0-9]+", text.lower())
+    unigrams = set(words)
+    bigrams  = {f"{words[i]} {words[i+1]}" for i in range(len(words) - 1)}
+    stemmed  = {_stem(w) for w in words}
+    return unigrams | bigrams | stemmed
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Data classes
+# ─────────────────────────────────────────────────────────────────────────────
+
+@dataclass
+class IdentifiedRisk:
+    id: str
+    label: str
+    group: str
+    sources: List[str]
+    score: float
+    tfidf_score: float
+    keyword_score: float
+    relevance: str
+    matched_keywords: List[str] = field(default_factory=list)
+
+    def __repr__(self) -> str:
+        bar = "█" * int(self.score * 30)
+        kw = f"  kw=[{', '.join(self.matched_keywords[:4])}]" if self.matched_keywords else ""
+        return (
+            f"[{self.relevance.upper():6}] {self.label:<42} "
+            f"score={self.score:.3f}  {bar}{kw}"
+        )
+
+
+@dataclass
+class UsecaseRiskResult:
+    usecase: str
+    risks: List[IdentifiedRisk]
+
+    @property
+    def high(self) -> List[IdentifiedRisk]:
+        return [r for r in self.risks if r.relevance == "high"]
+
+    @property
+    def medium(self) -> List[IdentifiedRisk]:
+        return [r for r in self.risks if r.relevance == "medium"]
+
+    @property
+    def low(self) -> List[IdentifiedRisk]:
+        return [r for r in self.risks if r.relevance == "low"]
+
+    def to_dict(self) -> dict:
+        return {
+            "usecase": self.usecase,
+            "risks": [
+                {"id": r.id, "label": r.label, "group": r.group,
+                 "relevance": r.relevance, "score": r.score,
+                 "matched_keywords": r.matched_keywords, "sources": r.sources}
+                for r in self.risks
+            ],
+        }
+
+    def __repr__(self) -> str:
+        snippet = self.usecase[:90] + ("…" if len(self.usecase) > 90 else "")
+        lines = [f"\nUse case: {snippet}", f"Identified {len(self.risks)} risk(s):"]
+        for r in self.risks:
+            lines.append(f"  {r}")
+        return "\n".join(lines)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Classifier
+# ─────────────────────────────────────────────────────────────────────────────
+
+class AIRiskClassifier:
+    """
+    Multi-label AI risk classifier (TF-IDF + keyword hybrid).
+    Works with Risk objects from ai-atlas-nexus or custom risk taxonomy dicts.
+
+    Parameters
+    ----------
+    risks : list[Any]
+        Risk objects (from ai-atlas-nexus) or dicts (custom taxonomy).
+        Required parameter. No default taxonomy provided.
+    threshold_high : float
+        Score ≥ this → "high" relevance.  Default 0.30.
+    threshold_medium : float
+        Score ≥ this → "medium" relevance.  Default 0.12.
+    alpha : float
+        Weight of TF-IDF component (0–1).  Default 0.35.
+    aggregation : {"max", "mean"}
+        How to pool per-anchor TF-IDF scores.  Default "max".
+    keyword_top_k : int
+        Max keywords per risk after corpus-level extraction (default 20).
+    keyword_max_df : float
+        Drop terms appearing in >max_df fraction of risks (default 0.5).
+    keyword_min_word_len : int
+        Ignore tokens shorter than this (default 3).
+
+    Examples
+    --------
+    # Use IBM Risk Atlas from ai-atlas-nexus
+    clf = AIRiskClassifier.from_nexus(taxonomy='ibm-risk-atlas')
+
+    # Use custom risk taxonomy
+    my_risks = [{
+        'id': 'my-risk',
+        'label': 'My Risk',
+        'group': 'custom',
+        'sources': [],
+        'anchors': ['risk description'],
+        'keywords': ['risk', 'keyword'],
+        'kw_norm': 2,
+    }]
+    clf = AIRiskClassifier(risks=my_risks)
+    """
+
+    def __init__(
+        self,
+        risks:            list,
+        threshold_high:   float = 0.30,
+        threshold_medium: float = 0.12,
+        alpha:            float = 0.35,
+        aggregation:      str = "max",
+        keyword_top_k:    int = 20,
+        keyword_max_df:   float = 0.5,
+        keyword_min_word_len: int = 3,
+    ):
+        if not risks:
+            raise ValueError(
+                "risks parameter is required. Either:\n"
+                "  1. Use AIRiskClassifier.from_nexus(taxonomy='ibm-risk-atlas')\n"
+                "  2. Pass a custom risk taxonomy dict: AIRiskClassifier(risks=[...])"
+            )
+
+        self.threshold_high   = threshold_high
+        self.threshold_medium = threshold_medium
+        self.alpha            = alpha
+        self.aggregation      = aggregation
+        self.keyword_top_k    = keyword_top_k
+        self.keyword_max_df   = keyword_max_df
+        self.keyword_min_word_len = keyword_min_word_len
+
+        # Normalize Risk objects → internal dict format
+        raw_risks = risks
+
+        # Normalize Risk objects → internal dict format
+        self.taxonomy = [self._risk_to_dict(r) for r in raw_risks]
+
+        # Extract keywords for auto-extracted risks (corpus-level, with stopword/max_df filtering)
+        self._auto_extract_keywords()
+
+        # Build TF-IDF over all anchor sentences
+        corpus: list[str] = []
+        self._anchor_slices: list[slice] = []
+        idx = 0
+        for risk in self.taxonomy:
+            n = len(risk["anchors"])
+            self._anchor_slices.append(slice(idx, idx + n))
+            corpus.extend(risk["anchors"])
+            idx += n
+
+        self._vectorizer = TfidfVectorizer(
+            ngram_range=(1, 2), sublinear_tf=True, min_df=1,
+            analyzer="word", strip_accents="unicode",
+        )
+        self._anchor_matrix = self._vectorizer.fit_transform(corpus)
+
+        # Pre-tokenize keyword sets for all risks
+        self._precompute_keywords()
+
+    def _auto_extract_keywords(self):
+        """
+        Extract keywords for all auto-extracted risks using corpus-level TF-IDF.
+        Applies to risks without hand-curated keywords (Risk objects from nexus).
+        Static taxonomy risks (already with keywords) are skipped.
+        """
+        pending = [r for r in self.taxonomy if "keywords" not in r]
+        if not pending:
+            return
+
+        texts = [r["_extraction_text"] for r in pending]
+        keyword_lists = _extract_keywords_corpus(
+            texts,
+            top_k=self.keyword_top_k,
+            max_df=self.keyword_max_df,
+            min_word_len=self.keyword_min_word_len,
+        )
+
+        for risk, kws in zip(pending, keyword_lists):
+            risk["keywords"] = kws
+            risk["kw_norm"] = max(3, len(kws) // 2) if kws else 1
+            risk.pop("_extraction_text", None)
+
+    def _precompute_keywords(self):
+        """Pre-tokenize keyword sets once to speed up scoring."""
+        for _risk in self.taxonomy:
+            _kw_tokens: set[str] = set()
+            for kw in _risk["keywords"]:
+                _kw_tokens.update(_tokenize(kw))
+            _risk["_kw_tokens"] = _kw_tokens
+
+    @classmethod
+    def from_nexus(
+        cls,
+        taxonomy: Optional[str] = "ibm-risk-atlas",
+        threshold_high: float = 0.30,
+        threshold_medium: float = 0.12,
+        alpha: float = 0.35,
+        aggregation: str = "max",
+        keyword_top_k: int = 20,
+        keyword_max_df: float = 0.5,
+        keyword_min_word_len: int = 3,
+    ):
+        """
+        Initialize classifier with risks from ai-atlas-nexus library.
+
+        Parameters
+        ----------
+        taxonomy : str | None
+            Taxonomy name to filter risks (e.g., 'ibm-risk-atlas', 'nist-ai-rmf').
+            Pass None to load all risks.
+        threshold_high, threshold_medium, alpha, aggregation : float, str
+            Same as __init__.
+        keyword_top_k : int
+            Maximum keywords per risk after corpus-level TF-IDF extraction (default 20).
+        keyword_max_df : float
+            Drop terms appearing in >max_df fraction of risks (default 0.5).
+            E.g. 0.5 drops terms in >50% of risks.
+        keyword_min_word_len : int
+            Ignore tokens shorter than this (default 3, filters "a", "ai", "or").
+
+        Returns
+        -------
+        AIRiskClassifier
+            Classifier initialized with nexus risks.
+
+        Raises
+        ------
+        ImportError
+            If ai_atlas_nexus is not installed.
+        """
+        try:
+            from ai_atlas_nexus import AIAtlasNexus
+        except ImportError:
+            raise ImportError(
+                "ai-atlas-nexus is required for from_nexus(). "
+                "Install with: pip install ai-atlas-nexus"
+            )
+
+        nexus = AIAtlasNexus()
+        risks = nexus.get_all_risks(taxonomy=taxonomy)
+
+        return cls(
+            threshold_high=threshold_high,
+            threshold_medium=threshold_medium,
+            alpha=alpha,
+            risks=risks,
+            aggregation=aggregation,
+            keyword_top_k=keyword_top_k,
+            keyword_max_df=keyword_max_df,
+            keyword_min_word_len=keyword_min_word_len,
+        )
+
+    @staticmethod
+    def _risk_to_dict(risk: Any) -> dict:
+        """
+        Convert a Risk object from ai-atlas-nexus to dict format for classifier.
+
+        Parameters
+        ----------
+        risk : Risk or dict
+            Risk object from ai-atlas-nexus or dict (passthrough).
+
+        Returns
+        -------
+        dict
+            Risk dict with keys: id, label, group, sources, anchors, keywords, kw_norm.
+        """
+        # If already a dict, return as-is
+        if isinstance(risk, dict):
+            return risk
+
+        # Risk object from ai-atlas-nexus
+        # Extract text anchors: description + concern + any related text
+        anchors = []
+        if hasattr(risk, "description") and risk.description:
+            anchors.append(risk.description)
+        if hasattr(risk, "concern") and risk.concern:
+            anchors.append(risk.concern)
+        if hasattr(risk, "name") and risk.name:
+            anchors.append(risk.name)
+
+        # Determine group/category from risk_type or taxonomy
+        group = getattr(risk, "risk_type", "uncategorized")
+        if not group:
+            group = "uncategorized"
+
+        # Get sources from related metadata
+        sources = []
+        if hasattr(risk, "isDefinedByTaxonomy") and risk.isDefinedByTaxonomy:
+            sources.append(risk.isDefinedByTaxonomy)
+
+        # For auto-extracted risks (no hand-curated keywords), defer extraction to corpus level
+        # Store raw text and mark for batch processing
+        return {
+            "id": risk.tag or risk.id,
+            "label": risk.name or risk.tag,
+            "group": group,
+            "sources": sources,
+            "anchors": anchors if anchors else [risk.name or ""],
+            "_extraction_text": _build_extraction_text(risk),
+            "kw_norm": None,
+        }
+
+    # ------------------------------------------------------------------
+
+    def _keyword_scores(
+        self, text: str
+    ) -> tuple[np.ndarray, list[list[str]]]:
+        tokens = _tokenize(text)
+        scores  = np.zeros(len(self.taxonomy))
+        matches: list[list[str]] = []
+        for j, risk in enumerate(self.taxonomy):
+            kw_tokens = risk["_kw_tokens"]
+            norm      = risk.get("kw_norm", 5)
+            hits      = kw_tokens & tokens
+            scores[j] = min(len(hits) / norm, 1.0)
+            # Report original keyword strings that fired
+            fired = [kw for kw in risk["keywords"]
+                     if _tokenize(kw) & tokens]
+            matches.append(fired)
+        return scores, matches
+
+    # ------------------------------------------------------------------
+
+    def identify_risks_from_usecases(
+        self, usecases: List[str]
+    ) -> List[UsecaseRiskResult]:
+        """
+        Identify applicable risks for one or more AI use-case descriptions.
+
+        Parameters
+        ----------
+        usecases : list of str
+            Plain-text descriptions of AI system use cases.
+
+        Returns
+        -------
+        list of UsecaseRiskResult
+        """
+        uc_mat   = self._vectorizer.transform(usecases)
+        sim_full = cosine_similarity(uc_mat, self._anchor_matrix)
+
+        results = []
+        for i, uc_text in enumerate(usecases):
+            tfidf = np.zeros(len(self.taxonomy))
+            for j, sl in enumerate(self._anchor_slices):
+                sims = sim_full[i, sl]
+                tfidf[j] = sims.max() if self.aggregation == "max" else sims.mean()
+
+            kw, kw_matches = self._keyword_scores(uc_text)
+            combined = self.alpha * tfidf + (1 - self.alpha) * kw
+
+            identified = []
+            for j, risk in enumerate(self.taxonomy):
+                s = float(combined[j])
+                if s >= self.threshold_medium:
+                    relevance = "high" if s >= self.threshold_high else "medium"
+                    identified.append(IdentifiedRisk(
+                        id=risk["id"], label=risk["label"],
+                        group=risk["group"], sources=risk["sources"],
+                        score=round(s, 4),
+                        tfidf_score=round(float(tfidf[j]), 4),
+                        keyword_score=round(float(kw[j]), 4),
+                        relevance=relevance,
+                        matched_keywords=kw_matches[j],
+                    ))
+
+            identified.sort(key=lambda r: r.score, reverse=True)
+            results.append(UsecaseRiskResult(usecase=uc_text, risks=identified))
+
+        return results
+
+    # ------------------------------------------------------------------
+
+    def score(self, usecases: List[str]) -> np.ndarray:
+        """
+        Return raw score matrix (n_usecases, n_risks).
+        Compatible with sklearn pipelines.
+        """
+        uc_mat   = self._vectorizer.transform(usecases)
+        sim_full = cosine_similarity(uc_mat, self._anchor_matrix)
+
+        tfidf = np.zeros((len(usecases), len(self.taxonomy)))
+        for j, sl in enumerate(self._anchor_slices):
+            col = sim_full[:, sl]
+            tfidf[:, j] = col.max(axis=1) if self.aggregation == "max" else col.mean(axis=1)
+
+        kw = np.zeros_like(tfidf)
+        for i, uc in enumerate(usecases):
+            kw[i], _ = self._keyword_scores(uc)
+
+        return self.alpha * tfidf + (1 - self.alpha) * kw
+
+    def risk_ids(self) -> List[str]:
+        return [r["id"] for r in self.taxonomy]
+
+    def __repr__(self) -> str:
+        return (
+            f"AIRiskClassifier(n_risks={len(self.taxonomy)}, "
+            f"vocab={len(self._vectorizer.vocabulary_)}, "
+            f"alpha={self.alpha}, "
+            f"thresholds=({self.threshold_medium}, {self.threshold_high}))"
+        )

--- a/ran-classifier/classifier/working_classifier.py
+++ b/ran-classifier/classifier/working_classifier.py
@@ -1,0 +1,17 @@
+from ai_risk_classifier import AIRiskClassifier
+
+clf = AIRiskClassifier()
+results = clf.identify_risks_from_usecases(
+    usecases=["An LLM answers customer questions about product recalls."]
+)
+for r in results:
+    print(r)
+
+usecases = ["an automated hiring system", "an llm assisted probation decider", "a medical system for cats"]
+
+results = clf.identify_risks_from_usecases(usecases=usecases)
+print(results)
+
+# For sklearn pipelines — returns (n_usecases, n_risks) score matrix
+scores = clf.score(usecases)
+print(scores)

--- a/ran-classifier/example_usage.py
+++ b/ran-classifier/example_usage.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+example_usage.py — AIRiskClassifier demonstrations
+
+Quick start (static taxonomy):
+    python example_usage.py
+
+With IBM Risk Atlas (requires ai-atlas-nexus):
+    pip install ai-atlas-nexus
+    python example_usage.py --nexus
+"""
+
+import sys
+sys.path.insert(0, 'classifier')
+
+from ai_risk_classifier import AIRiskClassifier
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--nexus', action='store_true', help='Use IBM Risk Atlas from ai-atlas-nexus')
+args = parser.parse_args()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Example 1: IBM Risk Atlas (from nexus or custom)
+# ─────────────────────────────────────────────────────────────────────────────
+
+print("=" * 80)
+if args.nexus:
+    print("EXAMPLE 1: IBM Risk Atlas from ai-atlas-nexus (~99 risks)")
+    print("=" * 80)
+    clf = AIRiskClassifier.from_nexus(taxonomy='ibm-risk-atlas')
+else:
+    print("EXAMPLE 1: IBM Risk Atlas from ai-atlas-nexus (~99 risks)")
+    print("(Note: Custom static taxonomy has been removed)")
+    print("=" * 80)
+    print("\nTo use this demo, run with --nexus flag or provide a custom taxonomy.")
+    print("Example: python example_usage.py --nexus")
+    sys.exit(0)
+
+print(f"\n{clf}\n")
+
+usecases = [
+    "An LLM answers patient questions about medications.",
+    "A hiring system screens job applications.",
+]
+
+for uc in usecases:
+    results = clf.identify_risks_from_usecases([uc])
+    print(results[0])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Example 2: Custom thresholds
+# ─────────────────────────────────────────────────────────────────────────────
+
+print("\n" + "=" * 80)
+print("EXAMPLE 2: Custom Thresholds (More Sensitive)")
+print("=" * 80)
+
+if args.nexus:
+    clf_sensitive = AIRiskClassifier.from_nexus(
+        taxonomy='ibm-risk-atlas',
+        threshold_high=0.15,
+        threshold_medium=0.06,
+        alpha=0.4
+    )
+else:
+    clf_sensitive = AIRiskClassifier(
+        threshold_high=0.15,
+        threshold_medium=0.06,
+        alpha=0.4
+    )
+
+usecase = "A chatbot helps users invest in stocks."
+results = clf_sensitive.identify_risks_from_usecases([usecase])
+print(f"\n{results[0]}")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Example 3: Raw score matrix for downstream analysis
+# ─────────────────────────────────────────────────────────────────────────────
+
+print("\n" + "=" * 80)
+print("EXAMPLE 3: Score Matrix (for ML pipelines)")
+print("=" * 80)
+
+usecases_batch = [
+    "An automated hiring system screens job applications and ranks candidates.",
+    "A generative AI assistant creates marketing content.",
+    "A medical AI diagnoses diseases from imaging.",
+]
+
+score_matrix = clf.score(usecases_batch)
+print(f"\nScore matrix shape: {score_matrix.shape}")
+print(f"  Rows: {score_matrix.shape[0]} use cases")
+print(f"  Cols: {score_matrix.shape[1]} risks")
+print(f"\nRaw scores (first 3 risks across 3 use cases):")
+print(score_matrix[:, :3])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Example 4: Explore other taxonomies (nexus only)
+# ─────────────────────────────────────────────────────────────────────────────
+
+if args.nexus:
+    print("\n" + "=" * 80)
+    print("EXAMPLE 4: Other Available Taxonomies")
+    print("=" * 80)
+
+    taxonomies = [
+        ('nist-ai-rmf', 'NIST AI RMF'),
+        ('mit-ai-risk-repository', 'MIT Risk Repository'),
+        ('owasp-llm-2.0', 'OWASP Top 10 for LLMs'),
+    ]
+
+    for tax_name, tax_label in taxonomies:
+        try:
+            clf_tax = AIRiskClassifier.from_nexus(taxonomy=tax_name)
+            print(f"  ✓ {tax_label:<30} {len(clf_tax.taxonomy)} risks")
+        except Exception as e:
+            print(f"  ✗ {tax_label:<30} (error: {str(e)[:40]})")
+
+print("\n" + "=" * 80)

--- a/ran-classifier/requirements.txt
+++ b/ran-classifier/requirements.txt
@@ -1,0 +1,5 @@
+scikit-learn>=1.0.0
+numpy>=1.20.0
+pandas>=1.3.0
+jupyter>=1.0.0
+ai-atlas-nexus>=0.1.0


### PR DESCRIPTION
# Example AI Risk ML Classifier with IBM Risk Atlas risks

A multi-label AI risk classification system that identifies applicable risks from AI use-case descriptions using the **IBM Risk Atlas** definitions via ai-atlas-nexus.

**Approach**: Hybrid scoring combining TF-IDF cosine similarity (vocabulary overlap) and domain keyword extraction (semantic coverage from ontology).

**Risk Taxonomy**: ~99 risks from the **IBM Risk Atlas**, or another preloaded taxonomy of your choice, or even your own set of risks loaded with the ai-atlas-nexus library.

